### PR TITLE
Wrap string vars in quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,9 @@ module.exports = function(opt) {
         }
 
         if (typeof val !== 'object') {
+          if (typeof val === 'string') {
+            val = '"' + val + '"';
+          }
           cb('$' + path + key + ': ' + val + opt.eol);
         } else {
           loadVariablesRecursive(val, path + key + opt.delim, cb);


### PR DESCRIPTION
I was having trouble with variables for filenames not escaping correctly. Perhaps I was using it wrong but it seems much simpler to wrap strings with quotes.