### PR TITLE
Add new option to prefix without numbers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ module.exports = function(opt) {
   opt.escapeIllegalCharacters = opt.escapeIllegalCharacters === undefined ? true : opt.escapeIllegalCharacters;
   opt.firstCharacter = opt.firstCharacter || '_';
   opt.prefixFirstNumericCharacter = opt.prefixFirstNumericCharacter === undefined ? true : opt.prefixFirstNumericCharacter;
-
+  opt.prefixNoNumbers = opt.prefixNoNumbers === undefined ? true : opt.prefixNoNumbers;
+    
   return through(processJSON);
 
   /////////////
@@ -75,9 +76,13 @@ module.exports = function(opt) {
 
         // sass variables cannot begin with a number
         if (path === '' && firstCharacterIsNumber.exec(key) && opt.prefixFirstNumericCharacter) {
-          key = opt.firstCharacter + key;
+            if (opt.prefixNoNumbers) {
+                key = opt.firstCharacter;
+            } else {
+                key = opt.firstCharacter + key;
+            }
         }
-
+          
         if (typeof val !== 'object') {
           cb('$' + path + key + ': ' + val + opt.eol);
         } else {


### PR DESCRIPTION
I found that JSON.parse creates a numeric index when parsing a JSON document (due to array). This makes its way into the output. To suppress this, I added a minor modification -- a new option `prefixNoNumbers` which is `true` by default, so a number will not prepend generated sass variables. Use `opt.prefixNoNumbers: false` to keep the number in the prefix. 